### PR TITLE
Add Content-Id and Content-Transfer-Encoding parsing

### DIFF
--- a/email/header.go
+++ b/email/header.go
@@ -161,6 +161,21 @@ func (h Header) ContentDisposition() (string, map[string]string, error) {
 	return h.parseMediaType("Content-Disposition")
 }
 
+// ContentID parses and returns the content Id
+// and an empty string if there is no content id header field.
+func (h Header) ContentID() string {
+	cid := h.Get("Content-Id")
+	cid = strings.TrimPrefix(cid, "<")
+	cid = strings.TrimSuffix(cid, ">")
+	return cid
+}
+
+// ContentEncoding parses and returns the content transfer encoding
+// and an empty string if there is no content transfer encoding header field.
+func (h Header) ContentEncoding() string {
+	return h.Get("Content-Transfer-Encoding")
+}
+
 // parseMediaType ...
 func (h Header) parseMediaType(typeField string) (string, map[string]string, error) {
 	if content := h.Get(typeField); len(content) > 0 {

--- a/email/parser.go
+++ b/email/parser.go
@@ -235,7 +235,8 @@ func contentReader(headers Header, bodyReader io.Reader) *bufio.Reader {
 	}
 
 	// if base64 - attempt to create a decode reader and test it by peeking
-	if headers.Get("Content-Transfer-Encoding") == "base64" {
+	// Ignore it if it's part of a Content-Id block then it will return as charset
+	if headers.Get("Content-Transfer-Encoding") == "base64" && headers.Get("Content-Id") == "" {
 		headers.Del("Content-Transfer-Encoding")
 		decReader := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(encoded_bytes))
 		decoded_bytes, err = ioutil.ReadAll(decReader)


### PR DESCRIPTION
Added Content-Id and Content-Transfer-Encoding parsing.

Return Base64 encoded chunks as charsets if they are also part of a Content-Id chunk rather than decoding them.